### PR TITLE
Remove outline color for bars

### DIFF
--- a/R/set_global_plot_theme.R
+++ b/R/set_global_plot_theme.R
@@ -41,7 +41,7 @@ set_global_plot_theme <- function(theme = "irx") {
     )
     ggplot2::update_geom_defaults(
       "rect",
-      ggplot2::aes(fill = "#35bcb1", color = "#35bcb1")
+      ggplot2::aes(fill = "#35bcb1", color = NA)
     )
   }
   

--- a/tests/testthat/test_set_global_plot_theme.R
+++ b/tests/testthat/test_set_global_plot_theme.R
@@ -3,7 +3,7 @@ test_that("set_global_plot_theme works for bar charts", {
 
   p <- ggplot2::ggplot(mtcars, ggplot2::aes(cyl)) + ggplot2::geom_bar()
   dat <- ggplot2::layer_data(p)
-  expect_true(all(dat$colour == "#35bcb1"))
+  expect_true(all(is.na(dat$colour)))
   expect_true(all(dat$fill == "#35bcb1"))
 })
 
@@ -12,6 +12,6 @@ test_that("set_global_plot_theme works for histograms", {
 
   p <- ggplot2::ggplot(mtcars, ggplot2::aes(x = mpg)) + ggplot2::geom_histogram()
   dat <- ggplot2::layer_data(p)
-  expect_true(all(dat$colour == "#35bcb1"))
+  expect_true(all(is.na(dat$colour)))
   expect_true(all(dat$fill == "#35bcb1"))
 })


### PR DESCRIPTION
Removes outline color for bars so that if the default bar fill color gets overridden, we don't have a teal outline around each bar.

Before: 
``` r
library("ggplot2")
library("irxadmiral")
set_global_plot_theme("irx")

ggplot(mpg, aes(x = class, fill = as.factor(cyl))) +
  geom_bar(position = position_dodge())
```

![](https://i.imgur.com/7f1aJ6A.png)<!-- -->

<sup>Created on 2023-11-08 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

After:

![](https://i.imgur.com/w0sQHjq.png)<!-- -->

