### PR TITLE
Fixes an issue with output table from fit not showing objective function values (OFV)

### DIFF
--- a/R/run_modelfit.R
+++ b/R/run_modelfit.R
@@ -43,7 +43,7 @@ run_modelfit <- function(
     data,
     est = "saem",
     nlmixr2::saemControl(print=50, nBurn=100, nEm=150), # limit to 250 iterations for now
-    nlmixr2::tableControl(cwres=FALSE, npde=TRUE)
+    nlmixr2::tableControl(cwres=TRUE, npde=TRUE)
   )
 
   ## save fit object to file


### PR DESCRIPTION
<img width="684" alt="image" src="https://github.com/InsightRX/irxadmiral/assets/15008273/1edf6b8a-e5ab-4418-89d5-901e9e26b778">

For the OFV (and AIC etc) to be calculated in nlmixr2, the CWRES need to be calculated.